### PR TITLE
Add precreate folder for db encryption to resolve issue with init

### DIFF
--- a/src/worklet/appDeps.js
+++ b/src/worklet/appDeps.js
@@ -255,6 +255,13 @@ export const initInstance = async ({ path, hashedPassword, encryptionKey }) => {
   try {
     const fullPath = buildPath(path)
 
+    // Pre-create the directory tree Corestore needs. Without this there's a
+    // race during Corestore.ready() on cold installs (notably on iOS App Group
+    // containers): RocksDB's non-recursive mkdir on `db/` can run before
+    // DeviceFile's recursive mkdir creates the parent, causing ENOENT with
+    // "While mkdir if missing: <path>/db: No such file or directory".
+    await fs.promises.mkdir(barePath.join(fullPath, 'db'), { recursive: true })
+
     const store = new Corestore(fullPath, CORE_STORE_OPTIONS)
 
     if (!store) {
@@ -301,6 +308,10 @@ export const initInstanceWithNewBlindEncryption = async ({
     }
 
     const fullPath = buildPath(path)
+
+    // Same rationale as initInstance — pre-create Corestore's directory tree
+    // to avoid an ENOENT race during Corestore.ready() on cold installs.
+    await fs.promises.mkdir(barePath.join(fullPath, 'db'), { recursive: true })
 
     const store = new Corestore(fullPath, CORE_STORE_OPTIONS)
 


### PR DESCRIPTION
Add a recursive pre creation on folder before new `Corestore(...)`, so Corestore never has to create its own parent directory tree.

Without this, there's an intermittent init race on cold installs (notably on iOS App Group containers): RocksDB's non-recursive mkdir on db/ can run before DeviceFile's recursive mkdir creates the parent, causing Error initializing instance: While mkdir if missing: <path>/db: No such file or directory, which cascades into encryption failing to initialize, the rate limiter staying null, and downstream crashes in consumer apps.


Previously:

https://github.com/user-attachments/assets/63b30dc3-1373-4cb2-bf7e-3ee148e17c6b

After:

IOS
https://github.com/user-attachments/assets/2b285517-84bb-45b2-a583-6e9c2b599e2a


Desktop:
https://github.com/user-attachments/assets/4dfc6e79-6070-4814-a02b-95eda7558a9e

Android:
https://github.com/user-attachments/assets/95bc01b7-5a9f-477d-b29f-f3f47971c495


