### PR TITLE
harden worklet storage lifecycle

### DIFF
--- a/src/worklet/appCore.js
+++ b/src/worklet/appCore.js
@@ -1053,30 +1053,71 @@ export const setupIPC = () => {
   if (typeof Bare !== 'undefined') {
     workletLogger.log('Bare lifecycle events detected')
 
+    let suspendDeadline = 0
+
     const sus = new Suspendify({
+      wakeupLinger: 6_000,
+      async pollLinger () {
+        const remaining = Math.max(suspendDeadline - Date.now(), 0)
+        workletLogger.log('Suspendify pollLinger remaining', remaining)
+        return remaining
+      },
+      async presuspend () {
+        workletLogger.log('Suspendify presuspend starting')
+      },
       async suspend () {
-        workletLogger.log('Suspendify suspending instances')
-        await suspendAllInstances()
-        workletLogger.log('Instances suspended successfully')
+        try {
+          workletLogger.log('Suspendify suspending instances')
+          await suspendAllInstances()
+          workletLogger.log('Instances suspended successfully')
+
+          if (sus.interrupted) {
+            workletLogger.log('Suspend interrupted, skipping Bare.idle')
+            return
+          }
+
+          if (typeof Bare.idle === 'function') {
+            workletLogger.log('Asking Bare to go idle')
+            Bare.idle()
+          } else {
+            workletLogger.log('Bare.idle is unavailable')
+          }
+        } catch (error) {
+          workletLogger.error('Caught suspension error:', error)
+        }
+      },
+      async suspendCancelled () {
+        workletLogger.log('Suspendify suspend cancelled')
       },
       async resume () {
-        workletLogger.log('Suspendify resuming instances')
-        await resumeAllInstances()
-        workletLogger.log('Instances resumed successfully')
+        try {
+          workletLogger.log('Suspendify resuming instances')
+          await resumeAllInstances()
+          workletLogger.log('Instances resumed successfully')
+        } catch (error) {
+          workletLogger.error('Caught resume error:', error)
+        }
       }
     })
 
     // eslint-disable-next-line no-undef
     Bare.on('suspend', function (linger) {
       linger = Math.max(linger - 20_000, 0)
+      suspendDeadline = Date.now() + linger
       workletLogger.log('Bare suspend, linger', linger)
       workletLogger.log('Asking suspendify to suspend')
-      sus.suspend(linger)
+      void sus.suspend(linger)
     })
     // eslint-disable-next-line no-undef
     Bare.on('resume', function () {
+      suspendDeadline = 0
       workletLogger.log('Bare resume event detected')
-      sus.resume()
+      void sus.resume()
+    })
+    // eslint-disable-next-line no-undef
+    Bare.on('idle', function () {
+      // eslint-disable-next-line no-console
+      console.log('Bare has fully idled')
     })
   }
 

--- a/src/worklet/appDeps.js
+++ b/src/worklet/appDeps.js
@@ -463,6 +463,8 @@ export const encryptionInit = async () => {
     path: 'encryption'
   })
 
+  await encryptionInstance.base.update()
+
   isEncryptionInitialized = true
 }
 
@@ -493,6 +495,18 @@ export const encryptionAdd = async (key, data) => {
   }
 
   await encryptionInstance.add(key, JSON.stringify(data))
+  await encryptionInstance.base.update()
+  await encryptionInstance.base.view.flush()
+
+  const storage = encryptionInstance.store?.storage
+
+  if (storage?.db?.flush) {
+    await storage.db.flush()
+  }
+
+  if (storage?.flush) {
+    await storage.flush()
+  }
 }
 
 /**
@@ -793,21 +807,18 @@ export const restartActiveVault = async () => {
  * @returns {Promise<void>}
  */
 export const closeAllInstances = async () => {
-  const closeTasks = []
-
   if (isActiveVaultInitialized) {
-    closeTasks.push(closeActiveVaultInstance())
+    await closeActiveVaultInstance()
   }
 
   if (isVaultsInitialized) {
-    closeTasks.push(closeVaultsInstance())
+    await closeVaultsInstance()
   }
 
   if (isEncryptionInitialized) {
-    closeTasks.push(encryptionClose())
+    await encryptionClose()
   }
 
-  await Promise.all(closeTasks)
   clearRestartCache()
 }
 


### PR DESCRIPTION
Fixes three failures seen on PearPass Mobile during cold install, master password creation, and suspend/resume:

- **`While open a file for appending: .../encryption/db/000008.log: No such file or directory`** — happens on the second app launch after creating a master password. RocksDB tries to reopen a WAL segment that the WAL index says exists, but the file was never actually written to disk because the previous session suspended/exited before the buffered write was flushed. The DB is then unrecoverable and the user can't unlock their vault.

- **`Error initializing instance: File descriptor could not be locked`** — happens on startup immediately after a suspend/close cycle. The previous `closeAllInstances` ran its three closes concurrently via `Promise.all`, so the underlying Corestore/RocksDB file handles were released in an unpredictable order. Next open finds a handle still held and fails the exclusive lock.

- **Bare worker crashes (SIGSEGV / SIGTRAP) during suspend/resume** — an exception thrown inside the Suspendify `suspend` or `resume` callback propagated back into Bare's event handler, tearing down the worker thread mid-lifecycle. Also: we never called `Bare.idle()`, so even a "successful" suspend left Bare running — wasting battery and leaving the storage stack in an ambiguous half-suspended state that the next resume couldn't recover from cleanly. Thanks to @supersuryaansh for feedbacks on this.

### `appDeps.js`

- **`encryptionInit`**: await `base.update()` after init so the Autobase is caught up before we return. Otherwise the first read/write can race the base still replaying.
- **`encryptionAdd`**: flush `base` → `view` → RocksDB after every write. Guarantees the entry is durably on disk — critical for the one-shot `masterPassword` write, since losing it locks the user out permanently.
- **`closeAllInstances`**: close sequentially. Each layer fully releases its handles before the next starts unwinding, so the next `init` always finds a clean filesystem state.

### `appCore.js`

Bare suspend/resume hardening:
- try/catch around `suspend`/`resume` so failures log instead of killing the worker
- call `Bare.idle()` after suspend completes so Bare actually parks
- `void sus.suspend()/resume()` from Bare handlers (the emitter doesn't await returned promises)
- `pollLinger` + `suspendDeadline` + `wakeupLinger: 6000` so linger behaves stably

### Testing

Fresh install → create master password → restart → unlock, plus repeated background/foreground cycles. All three errors above no longer reproduce.
