### PR TITLE
fix: increase default timeout for DHT mirror key validation and improve error handling

### DIFF
--- a/src/middleware/validateMirrorKeyViaDHT.js
+++ b/src/middleware/validateMirrorKeyViaDHT.js
@@ -10,7 +10,7 @@ import { getSharedDHT } from '../worklet/utils/dht'
  */
 
 export const validateMirrorKeyViaDHT = async (key, options = {}) => {
-  const { timeoutMs = 5000 } = options
+  const { timeoutMs = 30000 } = options
 
   let decodedKey
   try {
@@ -41,8 +41,7 @@ export const validateMirrorKeyViaDHT = async (key, options = {}) => {
     // If no event is emitted, resolve with false after timeout
     const timer = setTimeout(() => resolveOnce(false), timeoutMs)
 
-    socket.once('error', () => resolveOnce(false))
-    socket.once('close', () => resolveOnce(false))
+    socket.on('error', () => {})
     socket.once('open', () => resolveOnce(true))
   })
 }


### PR DESCRIPTION
saving a blind peer key from a different network always failed at ~5s, now validation waits the full timeout, allowing relay negotiation to complete

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1214788405810617