### PR TITLE
Redact file name, favicon hostname, and active vault name from logs

### DIFF
--- a/src/worklet/appCore.js
+++ b/src/worklet/appCore.js
@@ -342,9 +342,9 @@ export const handleRpcCommand = async (req) => {
         const { key, name } = metaData ?? {}
         await activeVaultAdd(key, {}, buffer, name)
 
-        workletLogger.log({
-          stream: `Received stream data of size: ${buffer.length}`,
-          data: JSON.stringify(metaData)
+        workletLogger.log('Received file stream data', {
+          size: buffer.length,
+          key: metaData?.key
         })
 
         req.reply(JSON.stringify({ success: true, metaData }))

--- a/src/worklet/faviconManager.js
+++ b/src/worklet/faviconManager.js
@@ -22,7 +22,7 @@ const getFromCache = async ({ hostname, cacheKey, isVaultReady }) => {
   try {
     const cachedBuffer = await activeVaultGetFile(cacheKey)
     if (cachedBuffer) {
-      workletLogger.log('Favicon cache hit:', hostname)
+      workletLogger.log('Favicon cache hit')
       const base64 = Buffer.from(cachedBuffer).toString('base64')
       return `data:image/png;base64,${base64}`
     }
@@ -46,7 +46,7 @@ const saveToCache = async ({ hostname, cacheKey, buffer, isVaultReady }) => {
   if (!isVaultReady) return
 
   try {
-    workletLogger.log('Storing favicon to cache:', hostname)
+    workletLogger.log('Storing favicon to cache')
     await activeVaultAdd(
       cacheKey,
       { created_at: Date.now() },
@@ -86,7 +86,7 @@ export const faviconManager = {
     try {
       const imgResponse = await fetch(faviconUrl)
 
-      workletLogger.log('Fetching favicon from network:', hostname)
+      workletLogger.log('Fetching favicon from network')
 
       if (imgResponse.ok) {
         const arrayBuffer = await imgResponse.arrayBuffer()

--- a/src/worklet/utils/sanitizeRequestDataForLog.js
+++ b/src/worklet/utils/sanitizeRequestDataForLog.js
@@ -21,7 +21,7 @@ const redactKeyedPayload = (requestData) => {
   const data = requestData.data
   if (!data || typeof data !== 'object') return requestData
 
-  if (requestData.key.startsWith('vault/')) {
+  if (requestData.key === 'vault' || requestData.key.startsWith('vault/')) {
     if (data.name === undefined) return requestData
     return {
       ...requestData,


### PR DESCRIPTION
[Android/iOS][Logs extraction] The Items' data are displayed in the logs
[Android/iOS][Logs extraction] The Vault name is displayed in the logs


  ### File name in `ACTIVE_VAULT_FILE_ADD` stream log

  **Before:**
  ```
  {
    stream: 'Received stream data of size: 2501436',
    data: '{"key":"record/.../file/...","name":"1000027409.jpg"}'
  }
  ```

  **After:**
  ```
  Received file stream data { size: 2501436, key: 'record/.../file/...' }
  ```

  ### Favicon hostname

  **Before:**
  ```
  Fetching favicon from network: amazon.com
  Storing favicon to cache: amazon.com
  Favicon cache hit: amazon.com
  ```

  **After:**
  ```
  Fetching favicon from network
  Storing favicon to cache
  Favicon cache hit
  ```

  ### Active vault name (`ACTIVE_VAULT_ADD key: 'vault'`)

  **Before:**
  ```
  ACTIVE_VAULT_ADD {
    key: 'vault',
    data: { id: '...', name: 'Test vault android', version: 1, ... }
  }
  ```

  **After:**
  ```
  ACTIVE_VAULT_ADD {
    key: 'vault',
    data: { id: '...', name: '[REDACTED]', version: 1, ... }
  }