### PR TITLE
proton decryption logic

### DIFF
--- a/src/pearpassVaultClient/index.js
+++ b/src/pearpassVaultClient/index.js
@@ -980,6 +980,21 @@ export class PearpassVaultClient extends EventEmitter {
   }
 
   /**
+   * @param {Object} params
+   * @param {string} params.password
+   * @param {number} params.version        - must be 1
+   * @param {string} params.salt           - base64-encoded 16-byte random salt
+   * @param {string} params.content        - base64-encoded [nonce(12) || ciphertext || tag(16)]
+   * @returns {Promise<string>} Decrypted UTF-8 plaintext (the vault JSON)
+   */
+  async decryptProtonExport(params) {
+    return this._handleRequest({
+      command: API.ENCRYPTION_DECRYPT_PROTON_EXPORT,
+      data: params
+    })
+  }
+
+  /**
    * Generates OTP codes for a list of record IDs.
    * @param {string[]} recordIds
    * @returns {Promise<Array<{ recordId: string, code: string, timeRemaining?: number }>>}

--- a/src/worklet/api.js
+++ b/src/worklet/api.js
@@ -76,7 +76,8 @@ export const API = {
   VERIFY_SIGNATURE: 74,
   ON_PERSONAL_SWARM_ERROR: 75,
   FIND_OTP_DUPLICATES: 76,
-  EXPORT_OTP_RECORDS: 77
+  EXPORT_OTP_RECORDS: 77,
+  ENCRYPTION_DECRYPT_PROTON_EXPORT: 78
 }
 
 export const API_BY_VALUE = Object.entries(API).reduce((acc, [key, value]) => {

--- a/src/worklet/appCore.js
+++ b/src/worklet/appCore.js
@@ -63,6 +63,7 @@ import {
   exportOtpRecords
 } from './appDeps'
 import { decryptBitwardenExport } from './decryptBitwardenExport'
+import { decryptProtonExport } from './decryptProtonExport'
 import { decryptVaultKey } from './decryptVaultKey'
 import { encryptVaultKeyWithHashedPassword } from './encryptVaultKeyWithHashedPassword'
 import { encryptVaultWithKey } from './encryptVaultWithKey'
@@ -1001,6 +1002,24 @@ export const handleRpcCommand = async (req) => {
         req.reply(
           JSON.stringify({
             error: `Error decrypting Bitwarden export: ${error.message || error}`
+          })
+        )
+      }
+
+      break
+
+    case API.ENCRYPTION_DECRYPT_PROTON_EXPORT:
+      try {
+        const decryptedData = decryptProtonExport(
+          requestData,
+          requestData.password
+        )
+
+        req.reply(JSON.stringify({ data: decryptedData }))
+      } catch (error) {
+        req.reply(
+          JSON.stringify({
+            error: `Error decrypting Proton export: ${error.message || error}`
           })
         )
       }

--- a/src/worklet/decryptProtonExport.js
+++ b/src/worklet/decryptProtonExport.js
@@ -1,0 +1,135 @@
+import { gcm } from '@noble/ciphers/aes.js'
+import { argon2id } from '@noble/hashes/argon2.js'
+import sodium from 'sodium-native'
+
+import { workletLogger } from './utils/workletLogger'
+
+// Proton Authenticator v1 export: fixed Argon2id parameters sourced from
+// protonpass/proton-pass-common password_exporter.rs
+const ARGON2_M_COST = 19456 // KiB (19 MiB)
+const ARGON2_T_COST = 2
+const ARGON2_P_COST = 1
+const KEY_LENGTH = 32
+const NONCE_LENGTH = 12
+const TAG_LENGTH = 16
+// from proton-pass-common crypto.rs EncryptionTag::PasswordExport
+const GCM_AAD = Buffer.from('proton.authenticator.export.v1', 'utf8')
+
+const protonError = (code, message) => {
+  const err = new Error(message)
+  err.code = code
+  return err
+}
+
+// Copy transient key material into libsodium secure memory, then wipe origin.
+const toSecureBuffer = (bytes) => {
+  const secure = sodium.sodium_malloc(bytes.length)
+  secure.set(bytes)
+  bytes.fill(0)
+  return secure
+}
+
+// Dev helper: log the nonce / ciphertext / tag breakdown of a raw content frame.
+export const debugFrame = (buffer) => {
+  if (buffer.length < NONCE_LENGTH + TAG_LENGTH) {
+    workletLogger.info(
+      `[proton-debug] buffer too short: ${buffer.length} bytes`
+    )
+    return
+  }
+  const nonce = buffer.slice(0, NONCE_LENGTH)
+  const body = buffer.slice(NONCE_LENGTH)
+  const ct = body.slice(0, body.length - TAG_LENGTH)
+  const tag = body.slice(body.length - TAG_LENGTH)
+  workletLogger.info(
+    `[proton-debug] totalLen=${buffer.length} nonce=${nonce.toString('hex')} ctLen=${ct.length} tag=${tag.toString('hex')}`
+  )
+}
+
+// Returns a sodium_malloc'd secure buffer — caller must free.
+const deriveKey = (password, salt) => {
+  const passwordBuf = toSecureBuffer(Buffer.from(password, 'utf8'))
+  const saltBuf = toSecureBuffer(Buffer.from(salt))
+
+  workletLogger.info(
+    `[proton-worklet] deriveKey argon2id m=${ARGON2_M_COST} t=${ARGON2_T_COST} p=${ARGON2_P_COST} saltLen=${saltBuf.length}`
+  )
+
+  try {
+    const t = Date.now()
+    const derived = argon2id(passwordBuf, saltBuf, {
+      t: ARGON2_T_COST,
+      m: ARGON2_M_COST,
+      p: ARGON2_P_COST,
+      dkLen: KEY_LENGTH
+    })
+    workletLogger.info(`[proton-worklet] Argon2id done in ${Date.now() - t}ms`)
+    return toSecureBuffer(derived)
+  } finally {
+    sodium.sodium_memzero(passwordBuf)
+    sodium.sodium_memzero(saltBuf)
+    sodium.sodium_free(passwordBuf)
+    sodium.sodium_free(saltBuf)
+  }
+}
+
+// Decrypt frame = [nonce(12) || ciphertext || tag(16)] with AES-256-GCM + AAD.
+const decryptAESGCM = (key, frame) => {
+  const nonce = frame.slice(0, NONCE_LENGTH)
+  const ciphertextWithTag = frame.slice(NONCE_LENGTH)
+
+  workletLogger.info(
+    `[proton-worklet] decryptAESGCM nonce=${nonce.toString('hex').slice(0, 8)}… ctWithTagLen=${ciphertextWithTag.length}`
+  )
+
+  try {
+    return Buffer.from(gcm(key, nonce, GCM_AAD).decrypt(ciphertextWithTag))
+  } catch {
+    throw protonError('PROTON_BAD_PASSWORD', 'Incorrect password')
+  }
+}
+
+/**
+ * Decrypt a Proton Authenticator password-protected export.
+ *
+ * @param {{ version: number, salt: string, content: string }} input
+ * @param {string} password
+ * @returns {string} Decrypted UTF-8 JSON string
+ */
+export const decryptProtonExport = (input, password) => {
+  const { version, salt, content } = input
+
+  if (version !== 1) {
+    throw protonError(
+      'PROTON_UNSUPPORTED_VERSION',
+      `Unsupported export version: ${version}`
+    )
+  }
+
+  const saltBuf = Buffer.from(salt, 'base64')
+  const frame = Buffer.from(content, 'base64')
+
+  workletLogger.info(
+    `[proton-worklet] decryptProtonExport version=${version} saltLen=${saltBuf.length} frameLen=${frame.length}`
+  )
+
+  if (frame.length < NONCE_LENGTH + TAG_LENGTH) {
+    throw protonError(
+      'PROTON_INVALID_PAYLOAD',
+      `Content frame too short: ${frame.length} bytes`
+    )
+  }
+
+  const key = deriveKey(password, saltBuf)
+  try {
+    const plain = decryptAESGCM(key, frame)
+    try {
+      return plain.toString('utf8')
+    } finally {
+      plain.fill(0)
+    }
+  } finally {
+    sodium.sodium_memzero(key)
+    sodium.sodium_free(key)
+  }
+}

--- a/src/worklet/decryptProtonExport.test.js
+++ b/src/worklet/decryptProtonExport.test.js
@@ -1,0 +1,102 @@
+// Argon2id at Proton's production parameters (m=19456 KiB, t=2, p=1) takes
+// ~400ms per invocation in @noble's pure-JS implementation. Raise the timeout
+// so the suite doesn't flake on a busy CI runner.
+jest.setTimeout(30_000)
+
+jest.mock('./utils/workletLogger', () => ({
+  workletLogger: {
+    log: jest.fn(),
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn()
+  }
+}))
+
+import { decryptProtonExport } from './decryptProtonExport'
+
+// Known-answer vector generated with gen-proton-vector.mjs using the exact
+// same @noble/ciphers + @noble/hashes stack that the production module uses.
+const PASSWORD = 'correct horse battery staple'
+const EXPECTED_PLAINTEXT =
+  '{"version":1,"user_data":{"totp":[{"name":"GitHub","issuer":"GitHub","secret":"JBSWY3DPEHPK3PXP","algorithm":"SHA1","digits":6,"period":30}]}}'
+
+const VECTOR = {
+  version: 1,
+  salt: 'cHJvdG9udGVzdHNh',
+  content:
+    'cHJvdG9ubm9uY2UxWnLLvZZ9+YuApaQwj1eUZKDRL6yl8mpaak5wF0L26osXezPK+bKIZkxwpg8ZIbgCwxQaqBYXqzKLX3iR3Agz8SSSoQ80cYTlvXU8UooWskqe7xJ5Zs1MEgXm5NPIgHsSTRl+ODmlKB+zHzNG3bSimS0tLYs1SlLrze8usFoUUclY2My0CWRZ6pHW+Et5Rf6OZdzGGHV84g3mBhmB+SY='
+}
+
+describe('decryptProtonExport', () => {
+  describe('happy path', () => {
+    it('decrypts a v1 export and returns the raw JSON string', () => {
+      expect(decryptProtonExport(VECTOR, PASSWORD)).toBe(EXPECTED_PLAINTEXT)
+    })
+  })
+
+  describe('authentication failures', () => {
+    it('throws on a wrong password', () => {
+      expect(() => decryptProtonExport(VECTOR, 'wrong password')).toThrow(
+        'Incorrect password'
+      )
+    })
+
+    it('exposes a stable PROTON_BAD_PASSWORD code on wrong password', () => {
+      expect.assertions(1)
+      try {
+        decryptProtonExport(VECTOR, 'wrong password')
+      } catch (err) {
+        expect(err.code).toBe('PROTON_BAD_PASSWORD')
+      }
+    })
+
+    it('throws when content has been tampered with', () => {
+      const frame = Buffer.from(VECTOR.content, 'base64')
+      // Flip a byte in the ciphertext region (after the 12-byte nonce)
+      frame[13] ^= 0xff
+      const tampered = { ...VECTOR, content: frame.toString('base64') }
+      expect(() => decryptProtonExport(tampered, PASSWORD)).toThrow(
+        'Incorrect password'
+      )
+    })
+  })
+
+  describe('unsupported version', () => {
+    it('throws on version !== 1', () => {
+      expect(() =>
+        decryptProtonExport({ ...VECTOR, version: 2 }, PASSWORD)
+      ).toThrow('Unsupported export version')
+    })
+
+    it('exposes a stable PROTON_UNSUPPORTED_VERSION code', () => {
+      expect.assertions(1)
+      try {
+        decryptProtonExport({ ...VECTOR, version: 2 }, PASSWORD)
+      } catch (err) {
+        expect(err.code).toBe('PROTON_UNSUPPORTED_VERSION')
+      }
+    })
+  })
+
+  describe('malformed payload', () => {
+    it('throws on content that is too short to contain a nonce and tag', () => {
+      const tiny = { ...VECTOR, content: Buffer.alloc(10).toString('base64') }
+      expect(() => decryptProtonExport(tiny, PASSWORD)).toThrow(
+        'Content frame too short'
+      )
+    })
+
+    it('exposes a stable PROTON_INVALID_PAYLOAD code on short content', () => {
+      expect.assertions(1)
+      try {
+        decryptProtonExport(
+          { ...VECTOR, content: Buffer.alloc(10).toString('base64') },
+          PASSWORD
+        )
+      } catch (err) {
+        expect(err.code).toBe('PROTON_INVALID_PAYLOAD')
+      }
+    })
+  })
+})


### PR DESCRIPTION
### Changes

- decryptProtonExport.js — new worklet module implementing the full decryption pipeline:
    - Argon2id key derivation (m=19456 KiB, t=2, p=1) with fixed parameters sourced from protonpass/proton-pass-common
    - AES-256-GCM decryption with AAD "proton.authenticator.export.v1" as required by Proton's  EncryptionTag::PasswordExport
    - Key material managed in libsodium secure memory (sodium_malloc / sodium_memzero / sodium_free) — password, salt, and derived key are all wiped after use
    - Frame layout: base64(nonce[12] || ciphertext || tag[16])
- api.js — ENCRYPTION_DECRYPT_PROTON_EXPORT: 78 added
- appCore.js — case handler added, mirrors ENCRYPTION_DECRYPT_BITWARDEN_EXPORT pattern; caller passes { version, salt, content, password }
- pearpassVaultClient/index.js — decryptProtonExport(params) method added with JSDoc
- 8 unit tests covering happy path, wrong password, tampered ciphertext, unsupported version, and short-frame rejection

### Testing Notes

- Implemented simple html document for testing

https://github.com/user-attachments/assets/791f05e1-aaa5-420d-ac1d-8691e4152a01



### Dependencies
https://github.com/tetherto/pearpass-lib-vault/pull/54